### PR TITLE
Github action fix - use files in gh-pages

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -12,11 +12,13 @@ jobs:
     name: Render-Book
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
       - uses: r-lib/actions/setup-r@v1
       - uses: r-lib/actions/setup-pandoc@v1
       - name: Install rmarkdown
-        run: Rscript -e 'install.packages(c("rmarkdown","bookdown"))'
+        run: Rscript -e 'install.packages(c("rmarkdown","bookdown","HelpersMG","readr"))'
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("/origin/resources/bookdown/Bookdown/index.Rmd")'
       - uses: actions/upload-artifact@v1


### PR DESCRIPTION
Change to workflow file to use the files in the gh-pages branch and to install additional required packages.